### PR TITLE
Refactor logging, error handling, and pluralization fixes

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -36,6 +36,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.FORGEJO_REGISTRY_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+        with:
+          driver: docker
+
       - name: Build and push
         uses: docker/build-push-action@eb6512707bea5740b2608f2a43ece7bc543cb75b  # v7.0.0
         with:

--- a/api.ts
+++ b/api.ts
@@ -24,7 +24,7 @@ export async function getHistory({
     });
     return res.data.history;
   } catch (err) {
-    await logError('Error getting history', err);
+    logError('Error getting history', err);
   }
 }
 
@@ -40,7 +40,7 @@ export async function removeHistoryItems(items: Item[]) {
     });
     return res.data.status;
   } catch (err) {
-    await logError('Error deleting history items', err);
+    logError('Error deleting history items', err);
   }
 }
 
@@ -53,7 +53,7 @@ export async function getWarnings() {
     });
     return res.data.warnings;
   } catch (err) {
-    await logError('Error getting warnings', err);
+    logError('Error getting warnings', err);
   }
 }
 
@@ -67,6 +67,6 @@ export async function clearAllWarnings() {
     });
     return res.data;
   } catch (err) {
-    await logError('Error clearing all warnings', err);
+    logError('Error clearing all warnings', err);
   }
 }

--- a/api.ts
+++ b/api.ts
@@ -25,6 +25,7 @@ export async function getHistory({
     return res.data.history;
   } catch (err) {
     logError('Error getting history', err);
+    return null;
   }
 }
 
@@ -41,6 +42,7 @@ export async function removeHistoryItems(items: Item[]) {
     return res.data.status;
   } catch (err) {
     logError('Error deleting history items', err);
+    return null;
   }
 }
 
@@ -54,6 +56,7 @@ export async function getWarnings() {
     return res.data.warnings;
   } catch (err) {
     logError('Error getting warnings', err);
+    return null;
   }
 }
 
@@ -68,5 +71,6 @@ export async function clearAllWarnings() {
     return res.data;
   } catch (err) {
     logError('Error clearing all warnings', err);
+    return null;
   }
 }

--- a/api.ts
+++ b/api.ts
@@ -15,10 +15,10 @@ export async function getHistory({
       params: {
         mode: 'history',
         start: start,
-        limit: limit || Number.MAX_SAFE_INTEGER,
+        limit: limit ?? Number.MAX_SAFE_INTEGER,
         cat: cat,
         search: search,
-        nzo_ids: nzoIds?.join() !== '' ? nzoIds?.join() : undefined,
+        nzo_ids: nzoIds?.length ? nzoIds.join() : undefined,
         last_history_update: lastHistoryUpdate || 0,
       },
     });

--- a/sanitize.ts
+++ b/sanitize.ts
@@ -94,7 +94,7 @@ async function sanitizeHistory() {
           config.categories.some((c) => i.name.toLowerCase().includes(c)))
       );
     };
-    const items = history.slots.filter((i) => filterFn(i));
+    const items = history.slots.filter(filterFn);
     if (items.length) {
       const result = await api.removeHistoryItems(items);
       if (result) {

--- a/sanitize.ts
+++ b/sanitize.ts
@@ -145,7 +145,7 @@ axios.defaults.params = {
 
 console.info(
   `${fmtTime()} sabnzbd-sanitizer initialized with config: ${JSON.stringify(
-    config,
+    { ...config, apiKey: '***' },
     null,
     2
   )}`

--- a/sanitize.ts
+++ b/sanitize.ts
@@ -64,7 +64,7 @@ async function sanitize() {
 async function sanitizeWarnings() {
   const warnings: { text: string }[] = await api.getWarnings();
   let clearedWarnings = false;
-  if (typeof warnings === 'object' && warnings.length) {
+  if (typeof warnings === 'object' && warnings !== null && warnings.length) {
     if (
       config.categories.some((category) =>
         warnings.some(

--- a/sanitize.ts
+++ b/sanitize.ts
@@ -65,15 +65,13 @@ async function sanitizeWarnings() {
   const warnings: { text: string }[] = await api.getWarnings();
   let clearedWarnings = false;
   if (typeof warnings === 'object' && warnings !== null && warnings.length) {
-    if (
-      config.categories.some((category) =>
-        warnings.some(
-          (warning) =>
-            warning.text.toLowerCase().includes(category) ||
-            warning.text.includes('Your UNRAR version is')
-        )
-      )
-    ) {
+    const hasMatchingWarning = config.categories.some((category) =>
+      warnings.some((w) => w.text.toLowerCase().includes(category))
+    );
+    const hasUnrarWarning = warnings.some((w) =>
+      w.text.includes('Your UNRAR version is')
+    );
+    if (hasMatchingWarning || hasUnrarWarning) {
       clearedWarnings = true;
       await api.clearAllWarnings();
       console.log(

--- a/util.ts
+++ b/util.ts
@@ -6,7 +6,7 @@ export function pluralize(something: any[] | number, suffix = 's'): string {
   }
 }
 
-export async function logError(description: string, err: unknown) {
+export function logError(description: string, err: unknown) {
   console.error(description + ':');
   if (err instanceof Error) {
     console.error(err.message);

--- a/util.ts
+++ b/util.ts
@@ -8,13 +8,12 @@ export function pluralize(something: any[] | number, suffix = 's'): string {
 
 export async function logError(description: string, err: unknown) {
   console.error(description + ':');
-  try {
-    if (err instanceof Error) {
-      console.error(JSON.stringify(err, null, 2));
-    } else {
-      console.error(err);
-    }
-  } catch {}
+  if (err instanceof Error) {
+    console.error(err.message);
+    if (err.stack) console.error(err.stack);
+  } else {
+    console.error(err);
+  }
 }
 
 export function pad(i: number) {

--- a/util.ts
+++ b/util.ts
@@ -1,9 +1,6 @@
 export function pluralize(something: any[] | number, suffix = 's'): string {
-  if (typeof something === 'number') {
-    return something > 1 ? suffix : '';
-  } else {
-    return something.length > 1 ? suffix : '';
-  }
+  const count = typeof something === 'number' ? something : something.length;
+  return count !== 1 ? suffix : '';
 }
 
 export function logError(description: string, err: unknown) {


### PR DESCRIPTION
## Summary

Code review fixes for `sanitize.ts`, `api.ts`, and `util.ts`:

- **fix:** `JSON.stringify(error)` produces `{}` — log `message` and `stack` instead
- **fix:** `pluralize` returned singular for 0 (`> 1` → `!== 1`)
- **fix:** null guard missing in `sanitizeWarnings` (`typeof null === 'object'`)
- **fix:** API key logged in plaintext at startup — now redacted
- **fix:** API error catch blocks returned implicit `undefined` — now explicit `null`
- **refactor:** remove unnecessary `async` from `logError` and `await` from callers
- **refactor:** extract UNRAR warning check from category loop (unrelated to `category`)
- **refactor:** pass `filterFn` directly to `Array.filter` instead of wrapping it
- **refactor:** use `??` instead of `||` for `limit` default; simplify `nzoIds` join
- **build:** use Docker Buildx